### PR TITLE
Sets as open variable the scroll view

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -97,7 +97,7 @@ open class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureRecogn
     // MARK: - Properties
     
     let menuScrollView = UIScrollView()
-    let controllerScrollView = UIScrollView()
+    open let controllerScrollView = UIScrollView()
     var controllerArray : [UIViewController] = []
     var menuItems : [MenuItemView] = []
     var menuItemWidths : [CGFloat] = []


### PR DESCRIPTION
The reason behind that change is to be able to change the isScrollEnabled. 
It gives additional customisation and prevents a scroll conflict especially if the contained View Controller has editable cells (swipe left to act)